### PR TITLE
Fix typo Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Stay tuned, we will open-source our circuit compiler in the incoming month.
 
 ## Orion PCS
 
-[Here](https://github.com/PolyhedraZK/Expander/tree/master/lib/Orion) provides a C++ implmenetation of [Orion](https://eprint.iacr.org/2022/1010.pdf) polynomial commitment, that can be coupled with other proof systems like (Virgo/Ligero/Hyrax/Spartan...) to achieve linear time zero-knowledge proofs.
+[Here](https://github.com/PolyhedraZK/Expander/tree/master/lib/Orion) provides a C++ implementation of [Orion](https://eprint.iacr.org/2022/1010.pdf) polynomial commitment, that can be coupled with other proof systems like (Virgo/Ligero/Hyrax/Spartan...) to achieve linear time zero-knowledge proofs.
 
 ## Roadmap
 


### PR DESCRIPTION
It looks like you're fixing the typo "implmenetation" in the readme.md file. The correct spelling is "implementation."

Here is the correction:

Original: "provides a C++ implmenetation of [Orion]..."
Corrected: "provides a C++ implementation of [Orion]..."
This change improves clarity and readability by fixing the spelling error.